### PR TITLE
Fix compat entry for Singular_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,4 +13,4 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [compat]
 JLLWrappers = "1.2.0"
 julia = "1.5"
-Singular_jll = "=402.0.1"
+Singular_jll = "~402.0.1"


### PR DESCRIPTION
This is a stop-gap measure until we can properly fix the underlying problem, and teach BB to support VersionSpec for dependencies correctly. But it'll save me some headaches...

ping @giordano -- merge please?